### PR TITLE
Update opencpu-0.4.js

### DIFF
--- a/opencpu-0.4.js
+++ b/opencpu-0.4.js
@@ -257,7 +257,7 @@
       var pngheight;
       
       var plotdiv = $('<div />').attr({
-        style: "width: 100%; height:100%; min-width: 100px; min-height: 100px; position:absolute; background-repeat:no-repeat; background-size: 100% 100%;"
+        style: "width: 100%; height:100%; min-width: 100px; min-height: 100px; position:relative; background-repeat:no-repeat; background-size: 100% 100%;"
       }).appendTo(targetdiv).css("background-image", "none");
       
       var spinner = $('<span />').attr({


### PR DESCRIPTION
removed the position absolute from the plotdiv style.  Really this should be declared as a css class, and a class assigned to the divs and spans so that the user can just change the css as needed.  But this is a quick fix
